### PR TITLE
bump circe version to 0.13.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Currently supporting the definition and creation of [timeboards](https://docs.da
 ## Getting It
 
 ```scala
-libraryDependencies += "com.supersonic" %% "scala-datadog-api" % "0.3.5"
+libraryDependencies += "com.supersonic" %% "scala-datadog-api" % "0.3.6"
 ``` 
 

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ def testDependencies = List(
   "org.scalatest" %% "scalatest" % "3.2.15" % "test")
 
 def circeDependencies = {
-  val circeVersion = "0.12.1"
+  val circeVersion = "0.13.0"
 
   List(
     "io.circe" %% "circe-core",


### PR DESCRIPTION
bumping the circe version due to conflict of versions and exceptions of uat's.

example:

`One failed assertion   Fiber failed.   An unchecked error was produced.   java.lang.NoSuchMethodError: io.circe.Encoder$.encodeList(Lio/circe/Encoder;)Lio/circe/ArrayEncoder;    at com.supersonic.datadog.DataDogSeriesJSON$.$anonfun$dataDogSeries$1(DataDogSeriesJSON.scala:8)    at io.circe.Encoder$$anon$3.apply(Encoder.scala:127)`